### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -26,7 +26,7 @@ router.post('/login', async (req, res) => {
   try {
     const { username, password } = req.body;
 
-    const user = await User.findOne({ username });
+    const user = await User.findOne({ username: { $eq: username } });
     if (!user) {
       return res.status(400).json({ message: 'User not found' });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Nec0ti/LibrisAPI/security/code-scanning/2](https://github.com/Nec0ti/LibrisAPI/security/code-scanning/2)

To fix the problem, we need to ensure that the `username` value is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This will ensure that the `username` is interpreted as a literal value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
