### PR TITLE
Potential fix for code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -8,7 +8,7 @@ router.post('/register', async (req, res) => {
   try {
     const { username, password } = req.body;
 
-    const existingUser = await User.findOne({ username });
+    const existingUser = await User.findOne({ username: { $eq: username } });
     if (existingUser) {
       return res.status(400).json({ message: 'Username is in use' });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Nec0ti/LibrisAPI/security/code-scanning/1](https://github.com/Nec0ti/LibrisAPI/security/code-scanning/1)

To fix the problem, we need to ensure that the user input is interpreted as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This will ensure that the `username` is treated as a literal string and not as a potential query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
